### PR TITLE
auth_proxy: fix tests / bump version

### DIFF
--- a/options.go
+++ b/options.go
@@ -100,6 +100,13 @@ func (o *Options) Validate() error {
 	if o.CookieSecret == "" {
 		msgs = append(msgs, "missing setting: cookie-secret")
 	}
+	if o.ClientID == "" {
+		msgs = append(msgs, "missing setting: client-id")
+	}
+	if o.ClientSecret == "" {
+		msgs = append(msgs, "missing setting: client-secret")
+	}
+
 	o.redirectUrl, msgs = parseUrl(o.RedirectUrl, "redirect", msgs)
 
 	for _, u := range o.Upstreams {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1"
+const VERSION = "2.0.1-buzzfeed0.1"


### PR DESCRIPTION
@buzzfeed/platform-infra please take a look at this, the test suite wasn't passing locally due to some issues in my vim configuration.

Secondly, it looks like I inadvertently landed a removal of the clientID/secret option requirements in #2. I added that back in here, as I think we're still going to be requiring auth_proxy installations to include google auth signin as well!