### PR TITLE
INFRA-820: add user-info cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Usage of auth_proxy:
   -cookie-domain="": an optional cookie domain to force cookies to (ie: .yourcompany.com)*
   -cookie-expire=168h0m0s: expire timeframe for cookie
   -cookie-httponly=true: set HttpOnly cookie flag
-  -cookie-key="_oauth2_proxy": the name of the cookie that the oauth_proxy creates
+  -cookie-key="_auth_proxy": the name of the cookie that the auth_proxy creates
   -cookie-refresh=0: refresh the cookie after this duration; 0 to disable
   -cookie-secret="": the seed string for secure cookies
   -cookie-secure=true: set secure (HTTPS) cookie flag

--- a/auth_api_test.go
+++ b/auth_api_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/bmizerany/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewAuthApiFromUrl(t *testing.T) {
+	url := "http://test.buzzfeed.com"
+	authApi, err := NewAuthApiFromUrl(url)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, authApi.url.Scheme, "http")
+	assert.Equal(t, authApi.url.Host, "test.buzzfeed.com")
+}
+
+func TestAuthApiValidate(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer backend.Close()
+	authApi, err := NewAuthApiFromUrl(backend.URL)
+	assert.Equal(t, err, nil)
+
+	verified := authApi.Validate("test", "test")
+	assert.Equal(t, verified, true)
+}
+
+func TestAuthApiValidateFailure(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+	}))
+	defer backend.Close()
+	authApi, err := NewAuthApiFromUrl(backend.URL)
+	assert.Equal(t, err, nil)
+
+	verified := authApi.Validate("test", "test")
+	assert.Equal(t, verified, false)
+}
+
+func TestAuthApiFetchUserInfo(t *testing.T) {
+	stubResponse := &AuthApiResponse{
+		Username: "test",
+		Email:    "test@buzzfeed.com",
+		Roles:    []string{"test"},
+	}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := json.Marshal(stubResponse)
+		assert.Equal(t, err, nil)
+		w.Write([]byte(data))
+		w.WriteHeader(200)
+	}))
+	defer backend.Close()
+
+	authApi, err := NewAuthApiFromUrl(backend.URL)
+	assert.Equal(t, err, nil)
+	response, err := authApi.FetchUserInfo("test")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, response, stubResponse)
+}
+
+func TestAuthApiFetchUserInfoFailure(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+	}))
+	defer backend.Close()
+
+	authApi, err := NewAuthApiFromUrl(backend.URL)
+	assert.Equal(t, err, nil)
+	response, err := authApi.FetchUserInfo("test")
+	assert.Equal(t, response == nil, true)
+	assert.Equal(t, err == nil, false)
+}

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -66,7 +66,7 @@
 ##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
 ## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
 ## HttpOnly - httponly cookies are not readable by javascript (recommended)
-# cookie_name = "_oauth2_proxy"
+# cookie_name = "_auth_proxy"
 # cookie_secret = ""
 # cookie_domain = ""
 # cookie_expire = "168h"

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
 
-	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
+	flagSet.String("cookie-name", "_auth_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
@@ -64,7 +64,8 @@ func main() {
 	flagSet.String("scope", "", "Oauth scope specification")
 
 	flagSet.String("auth-api-url", "", "[http://]<addr>:<port>/<path> of the BuzzFeed Auth API endpoint")
-	flagSet.Duration("auth-api-refresh", time.Duration(30), "auth-api refresh")
+	flagSet.Duration("auth-api-refresh", time.Hour*24, "auth-api refresh")
+	flagSet.String("auth-api-cookie-name", "_auth_proxy_user_info", "the name of the cookie for storing user info")
 
 	flagSet.Parse(os.Args[1:])
 
@@ -119,8 +120,12 @@ func main() {
 		}
 
 		oauthproxy.UserInfoHandler = &UserInfoHandler{
-			api:     oauthproxy.AuthApi,
-			refresh: opts.AuthApiRefresh,
+			api:            oauthproxy.AuthApi,
+			cookieExpire:   opts.AuthApiRefresh,
+			cookieName:     opts.AuthApiCookieName,
+			cookieSeed:     opts.CookieSecret,
+			cookieHttpOnly: opts.CookieHttpOnly,
+			cookieSecure:   opts.CookieSecure,
 		}
 	}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -412,7 +412,7 @@ func TestProcessCookieNoCookieError(t *testing.T) {
 	pc_test := NewProcessCookieTestWithDefaults()
 
 	session, _, err := pc_test.LoadCookiedSession()
-	assert.Equal(t, "Cookie \"_oauth2_proxy\" not present", err.Error())
+	assert.Equal(t, "Cookie \"_auth_proxy\" not present", err.Error())
 	if session != nil {
 		t.Errorf("expected nil session. got %#v", session)
 	}

--- a/options.go
+++ b/options.go
@@ -55,8 +55,9 @@ type Options struct {
 	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
 	// BuzzFeed Auth API options
-	AuthApiUrl     string        `flag:"auth-api-url" cfg:"auth_api_url"`
-	AuthApiRefresh time.Duration `flag:"auth-api-refresh" cfg:"auth_api_refresh"`
+	AuthApiUrl        string        `flag:"auth-api-url" cfg:"auth_api_url"`
+	AuthApiRefresh    time.Duration `flag:"auth-api-refresh" cfg:"auth_api_refresh"`
+	AuthApiCookieName string        `flag:"auth-api-cookie-name" cfg:"auth_api_cookie_name"`
 
 	// internal values that are set after config validation
 	redirectUrl   *url.URL
@@ -71,7 +72,7 @@ func NewOptions() *Options {
 		HttpAddress:         "127.0.0.1:4180",
 		HttpsAddress:        ":443",
 		DisplayHtpasswdForm: true,
-		CookieName:          "_oauth2_proxy",
+		CookieName:          "_auth_proxy",
 		CookieSecure:        true,
 		CookieHttpOnly:      true,
 		CookieExpire:        time.Duration(168) * time.Hour,
@@ -80,6 +81,8 @@ func NewOptions() *Options {
 		PassAccessToken:     false,
 		PassHostHeader:      true,
 		RequestLogging:      true,
+		AuthApiCookieName:   "_auth_proxy_user_info",
+		AuthApiRefresh:      time.Duration(24) * time.Hour,
 	}
 }
 

--- a/user_info_handler.go
+++ b/user_info_handler.go
@@ -1,44 +1,129 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/buzzfeed/auth_proxy/cookie"
 	"github.com/buzzfeed/auth_proxy/providers"
+	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 )
 
 type UserInfoHandler struct {
-	api     *AuthApi
-	refresh time.Duration
+	api            *AuthApi
+	cookieExpire   time.Duration
+	cookieDomain   string
+	cookieName     string
+	cookieSeed     string
+	cookieHttpOnly bool
+	cookieSecure   bool
 }
 
 type UserInfo map[string]string
 
 func (m *UserInfoHandler) Handle(rw http.ResponseWriter, req *http.Request, ses *providers.SessionState) error {
 	// by default, check to see if user information exists in a cookie
-	data, err := m.LoadCookiedData(req)
+	createCookie := true
+	userInfo, err := m.LoadCookiedData(req)
 	if err == nil {
+		createCookie = false
 		goto Save
 	}
-	data, err = m.FetchUserInfo(ses)
+	userInfo, err = m.FetchUserInfo(ses.User)
 	if err != nil {
 		return err
 	}
 
 Save:
-	m.WriteForwardedHeaders(req, data)
-	// TODO: add in a method to write cookie information
+	m.WriteForwardedHeaders(req, userInfo)
+	if createCookie {
+		err := m.WriteCookie(rw, req, userInfo)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (m *UserInfoHandler) LoadCookiedData(req *http.Request) (UserInfo, error) {
-	return nil, errors.New("Not implemented")
+	c, err := req.Cookie(m.cookieName)
+	if err != nil {
+		return nil, errors.New("No cookie found")
+	}
+
+	value, _, ok := cookie.Validate(c, m.cookieSeed, m.cookieExpire)
+	if !ok {
+		return nil, errors.New("Cookie not valid")
+	}
+
+	cipher, err := cookie.NewCipher(m.cookieSeed)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonString, err := cipher.Decrypt(value)
+	if err != nil {
+		return nil, err
+	}
+
+	userInfo := make(map[string]string, 3)
+	err = json.Unmarshal([]byte(jsonString), &userInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return userInfo, nil
 }
 
-func (m *UserInfoHandler) FetchUserInfo(ses *providers.SessionState) (UserInfo, error) {
-	res, err := m.api.FetchUserInfo(ses.User)
+func (m *UserInfoHandler) WriteCookie(rw http.ResponseWriter, req *http.Request, userInfo UserInfo) error {
+	jsonStr, err := json.Marshal(userInfo)
+	if err != nil {
+		return err
+	}
+
+	cipher, err := cookie.NewCipher(m.cookieSeed)
+	if err != nil {
+		return err
+	}
+
+	encryptedData, err := cipher.Encrypt(string(jsonStr))
+	if err != nil {
+		return err
+	}
+	cookieData := cookie.SignedValue(m.cookieSeed, m.cookieName, encryptedData, time.Now())
+
+	domain := req.Host
+	if h, _, err := net.SplitHostPort(domain); err == nil {
+		domain = h
+	}
+	if m.cookieDomain != "" {
+		if !strings.HasSuffix(domain, m.cookieDomain) {
+			log.Printf("Warning: request host is %q but using configured cookie domain of %q", domain, m.cookieDomain)
+		}
+		domain = m.cookieDomain
+	}
+
+	httpCookie := &http.Cookie{
+		Name:     m.cookieName,
+		Value:    cookieData,
+		Path:     "/",
+		Domain:   domain,
+		HttpOnly: m.cookieHttpOnly,
+		Secure:   m.cookieSecure,
+		Expires:  time.Now().Add(m.cookieExpire),
+	}
+	http.SetCookie(rw, httpCookie)
+
+	return nil
+}
+
+func (m *UserInfoHandler) FetchUserInfo(username string) (UserInfo, error) {
+	res, err := m.api.FetchUserInfo(username)
 	if err != nil {
 		return nil, err
 	}

--- a/user_info_handler_test.go
+++ b/user_info_handler_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/bmizerany/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestUserInfoLoadCookiedData(t *testing.T) {
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "127.0.0.1", nil)
+	handler := &UserInfoHandler{
+		api:            nil,
+		cookieExpire:   time.Minute,
+		cookieDomain:   "127.0.0.1",
+		cookieName:     "test",
+		cookieSeed:     "testtesttesttest",
+		cookieHttpOnly: true,
+		cookieSecure:   false,
+	}
+	userInfo := map[string]string{
+		"test": "test",
+	}
+	err := handler.WriteCookie(rw, req, userInfo)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, rw.Header()["Set-Cookie"][0] != "", true)
+	req.Header.Set("Cookie", rw.Header()["Set-Cookie"][0])
+
+	loadedUserInfo, err := handler.LoadCookiedData(req)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, loadedUserInfo["test"], userInfo["test"])
+}
+
+func TestUserInfoHeaders(t *testing.T) {
+	userInfo := map[string]string{
+		"test": "test",
+	}
+	handler := &UserInfoHandler{
+		api:            nil,
+		cookieExpire:   time.Minute,
+		cookieDomain:   "127.0.0.1",
+		cookieName:     "test",
+		cookieSeed:     "testtesttesttest",
+		cookieHttpOnly: true,
+		cookieSecure:   false,
+	}
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	handler.WriteForwardedHeaders(req, userInfo)
+
+	assert.Equal(t, req.Header["X-Forwarded-Test"][0], "test")
+}
+
+func TestUserInfoFetch(t *testing.T) {
+	userInfoResponse := &AuthApiResponse{
+		Username: "test",
+		Email:    "test@buzzfeed.com",
+		Roles:    []string{"test1", "test2"},
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := json.Marshal(userInfoResponse)
+		assert.Equal(t, err, nil)
+		w.Write([]byte(data))
+		w.WriteHeader(200)
+	}))
+	defer backend.Close()
+
+	authApi, err := NewAuthApiFromUrl(backend.URL)
+	handler := &UserInfoHandler{
+		api:            authApi,
+		cookieExpire:   time.Minute,
+		cookieDomain:   "127.0.0.1",
+		cookieName:     "test",
+		cookieSeed:     "testtesttesttest",
+		cookieHttpOnly: true,
+		cookieSecure:   false,
+	}
+
+	userInfo, err := handler.FetchUserInfo("test")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, userInfo["Roles"], "test1,test2")
+	assert.Equal(t, userInfo["Username"], "test")
+	assert.Equal(t, userInfo["Email"], "test@buzzfeed.com")
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.2"
+const VERSION = "2.0.1-buzzfeed0.3"


### PR DESCRIPTION
@buzzfeed/platform-infra please take a look through this first pass at adding a cookie into the `auth_proxy` to cache user-information.

This is still a WIP, I need to do some manual end to end testing and if time permits, add some unit tests in here as well. I'm open to suggestions now on how to make this better!