### PR TITLE
Check cookie secret size when passing --auth-api-url.

### DIFF
--- a/options.go
+++ b/options.go
@@ -135,7 +135,7 @@ func (o *Options) Validate() error {
 	}
 	msgs = parseProviderInfo(o, msgs)
 
-	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
+	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) || o.AuthApiUrl != "" {
 		valid_cookie_secret_size := false
 		for _, i := range []int{16, 24, 32} {
 			if len(o.CookieSecret) == i {
@@ -147,7 +147,8 @@ func (o *Options) Validate() error {
 				"cookie_secret must be 16, 24, or 32 bytes "+
 					"to create an AES cipher when "+
 					"pass_access_token == true or "+
-					"cookie_refresh != 0, but is %d bytes",
+					"cookie_refresh != 0 or "+
+					"auth_api_url != '', but is %d bytes",
 				len(o.CookieSecret)))
 		}
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -127,6 +127,25 @@ func TestPassAccessTokenRequiresSpecificCookieSecretLengths(t *testing.T) {
 	assert.Equal(t, nil, o.Validate())
 }
 
+func TestPassAuthApiUrlRequiresSpecificCookieSecretLengths(t *testing.T) {
+	o := testOptions()
+	assert.Equal(t, nil, o.Validate())
+
+	assert.Equal(t, "", o.AuthApiUrl)
+	o.AuthApiUrl = "http://api.buzzfeed.com/auth"
+	o.CookieSecret = "cookie of invalid length-"
+	assert.NotEqual(t, nil, o.Validate())
+
+	o.CookieSecret = "16 bytes AES-128"
+	assert.Equal(t, nil, o.Validate())
+
+	o.CookieSecret = "24 byte secret AES-192--"
+	assert.Equal(t, nil, o.Validate())
+
+	o.CookieSecret = "32 byte secret for AES-256------"
+	assert.Equal(t, nil, o.Validate())
+}
+
 func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {
 	o := testOptions()
 	assert.Equal(t, nil, o.Validate())

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.3"
+const VERSION = "2.0.1-buzzfeed0.4"


### PR DESCRIPTION
Since we use the Cipher to encrypt the `_auth_proxy_user_info` cookie, we should check the size of the cookie secret when using the `--auth-api-url` option.