### PR TITLE
auth_proxy: Use the existing X-Forwarded-User header

### DIFF
--- a/user_info_handler.go
+++ b/user_info_handler.go
@@ -130,7 +130,7 @@ func (m *UserInfoHandler) FetchUserInfo(username string) (UserInfo, error) {
 
 	userInfo := make(map[string]string, 3)
 	userInfo["Roles"] = strings.Join(res.Roles, ",")
-	userInfo["Username"] = res.Username
+	userInfo["User"] = res.Username
 	userInfo["Email"] = res.Email
 
 	return userInfo, nil


### PR DESCRIPTION
Instead of a new X-Forwarded-Username header.