### PR TITLE
auth_proxy: Keep track of auth method.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(2) do |config|
         ln -s /usr/local/gpm/bin/gpm /usr/local/bin
     fi
 
-    echo "export GOPATH=/opt/go" > /etc/profile.d/go.sh
+    echo "export GOPATH=/opt/go/src/github.com/buzzfeed/auth_proxy/.godeps:/opt/go" > /etc/profile.d/go.sh
     echo "export PATH=/opt/go/bin:$PATH" >> /etc/profile.d/go.sh
 
     if ! grep "cd /opt/go" /home/vagrant/.profile ; then

--- a/providers/auth_type.go
+++ b/providers/auth_type.go
@@ -1,0 +1,28 @@
+package providers
+
+type AuthType int
+
+const (
+	AuthTypeNone = iota
+	AuthTypeOAuth2
+	AuthTypeBasic
+	AuthTypeApi
+)
+
+func (authType AuthType) String() string {
+	return map[AuthType]string{
+		AuthTypeNone: "none",
+		AuthTypeOAuth2: "oauth2",
+		AuthTypeBasic: "basic_auth",
+		AuthTypeApi: "auth_api",
+	}[authType]
+}
+
+func AuthTypeFromString(s string) AuthType {
+	return map[string]AuthType{
+		"none": AuthTypeNone,
+		"oauth2": AuthTypeOAuth2,
+		"basic_auth": AuthTypeBasic,
+		"auth_api": AuthTypeApi,
+	}[s]
+}

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -22,10 +23,11 @@ func TestSessionStateSerialization(t *testing.T) {
 		AccessToken:  "token1234",
 		ExpiresOn:    time.Now().Add(time.Duration(1) * time.Hour),
 		RefreshToken: "refresh4321",
+		AuthType:     AuthTypeOAuth2,
 	}
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 3, strings.Count(encoded, "|"))
+	assert.Equal(t, 4, strings.Count(encoded, "|"))
 
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
@@ -34,6 +36,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	assert.Equal(t, s.AccessToken, ss.AccessToken)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.Equal(t, s.RefreshToken, ss.RefreshToken)
+	assert.Equal(t, s.AuthType, ss.AuthType)
 
 	// ensure a different cipher can't decode properly (ie: it gets gibberish)
 	ss, err = DecodeSessionState(encoded, c2)
@@ -52,10 +55,11 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 		AccessToken:  "token1234",
 		ExpiresOn:    time.Now().Add(time.Duration(1) * time.Hour),
 		RefreshToken: "refresh4321",
+		AuthType:     AuthTypeApi,
 	}
 	encoded, err := s.EncodeSessionState(nil)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, s.Email, encoded)
+	assert.Equal(t, fmt.Sprintf("%s|%s", s.AuthType, s.Email), encoded)
 
 	// only email should have been serialized
 	ss, err := DecodeSessionState(encoded, nil)

--- a/user_info_handler.go
+++ b/user_info_handler.go
@@ -139,6 +139,6 @@ func (m *UserInfoHandler) FetchUserInfo(username string) (UserInfo, error) {
 func (m *UserInfoHandler) WriteForwardedHeaders(req *http.Request, data UserInfo) {
 	for key, value := range data {
 		headerKey := fmt.Sprintf("X-Forwarded-%s", key)
-		req.Header.Add(headerKey, value)
+		req.Header.Set(headerKey, value)
 	}
 }

--- a/user_info_handler_test.go
+++ b/user_info_handler_test.go
@@ -83,6 +83,6 @@ func TestUserInfoFetch(t *testing.T) {
 	userInfo, err := handler.FetchUserInfo("test")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, userInfo["Roles"], "test1,test2")
-	assert.Equal(t, userInfo["Username"], "test")
+	assert.Equal(t, userInfo["User"], "test")
 	assert.Equal(t, userInfo["Email"], "test@buzzfeed.com")
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.4"
+const VERSION = "2.0.1-buzzfeed0.5"


### PR DESCRIPTION
Avoid making calls to `auth_api` and making the `_auth_proxy_user_info` cookie if the session was created via OAuth or Basic Auth.
