### PR TITLE
INFRA-835: Made the service more robust against auth_api failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ An example [oauth2_proxy.cfg](contrib/oauth2_proxy.cfg.example) config file is i
 ```
 Usage of auth_proxy:
   -auth-api-url="": [http://]<addr>:<port>/<path> of the BuzzFeed Auth API endpoint
+  -auth-api-refresh="24h": refresh user info after this duration
+  -auth-api-cookie-name="_auth_proxy_user_info": the name of the cookie for storing user info
   -authenticated-emails-file="": authenticate against emails via file (one per line)
   -client-id="": the OAuth Client ID: ie: "123456.apps.googleusercontent.com"
   -client-secret="": the OAuth Client Secret

--- a/auth_api_test.go
+++ b/auth_api_test.go
@@ -56,7 +56,7 @@ func TestAuthApiFetchUserInfo(t *testing.T) {
 
 	authApi, err := NewAuthApiFromUrl(backend.URL)
 	assert.Equal(t, err, nil)
-	response, err := authApi.FetchUserInfo("test")
+	response, _, err := authApi.FetchUserInfo("test")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, response, stubResponse)
 }
@@ -69,7 +69,7 @@ func TestAuthApiFetchUserInfoFailure(t *testing.T) {
 
 	authApi, err := NewAuthApiFromUrl(backend.URL)
 	assert.Equal(t, err, nil)
-	response, err := authApi.FetchUserInfo("test")
+	response, _, err := authApi.FetchUserInfo("test")
 	assert.Equal(t, response == nil, true)
 	assert.Equal(t, err == nil, false)
 }

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	flagSet.String("scope", "", "Oauth scope specification")
 
 	flagSet.String("auth-api-url", "", "[http://]<addr>:<port>/<path> of the BuzzFeed Auth API endpoint")
-	flagSet.Duration("auth-api-refresh", time.Hour*24, "auth-api refresh")
+	flagSet.Duration("auth-api-refresh", time.Hour*24, "refresh user info after this duration")
 	flagSet.String("auth-api-cookie-name", "_auth_proxy_user_info", "the name of the cookie for storing user info")
 
 	flagSet.Parse(os.Args[1:])
@@ -121,7 +121,8 @@ func main() {
 
 		oauthproxy.UserInfoHandler = &UserInfoHandler{
 			api:            oauthproxy.AuthApi,
-			cookieExpire:   opts.AuthApiRefresh,
+			refresh:        opts.AuthApiRefresh,
+			cookieExpire:   opts.CookieExpire,
 			cookieName:     opts.AuthApiCookieName,
 			cookieSeed:     opts.CookieSecret,
 			cookieHttpOnly: opts.CookieHttpOnly,

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -48,7 +48,7 @@ type OauthProxy struct {
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
 
-	AuthApi         *AuthApi
+	AuthApi         AuthApi
 	UserInfoHandler *UserInfoHandler
 }
 
@@ -548,6 +548,9 @@ func (p *OauthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 	if p.UserInfoHandler != nil && session.AuthType == providers.AuthTypeApi {
 		err := p.UserInfoHandler.Handle(rw, req, session)
 		if err != nil {
+			log.Printf("user info error: %s", err)
+			p.ClearCookie(rw, req)
+			p.SignInPage(rw, req, 403)
 			return
 		}
 	}

--- a/providers/auth_type.go
+++ b/providers/auth_type.go
@@ -11,18 +11,18 @@ const (
 
 func (authType AuthType) String() string {
 	return map[AuthType]string{
-		AuthTypeNone: "none",
+		AuthTypeNone:   "none",
 		AuthTypeOAuth2: "oauth2",
-		AuthTypeBasic: "basic_auth",
-		AuthTypeApi: "auth_api",
+		AuthTypeBasic:  "basic_auth",
+		AuthTypeApi:    "auth_api",
 	}[authType]
 }
 
 func AuthTypeFromString(s string) AuthType {
 	return map[string]AuthType{
-		"none": AuthTypeNone,
-		"oauth2": AuthTypeOAuth2,
+		"none":       AuthTypeNone,
+		"oauth2":     AuthTypeOAuth2,
 		"basic_auth": AuthTypeBasic,
-		"auth_api": AuthTypeApi,
+		"auth_api":   AuthTypeApi,
 	}[s]
 }

--- a/user_info_handler.go
+++ b/user_info_handler.go
@@ -14,7 +14,8 @@ import (
 )
 
 type UserInfoHandler struct {
-	api            *AuthApi
+	api            AuthApi
+	refresh        time.Duration
 	cookieExpire   time.Duration
 	cookieDomain   string
 	cookieName     string
@@ -23,40 +24,149 @@ type UserInfoHandler struct {
 	cookieSecure   bool
 }
 
-type UserInfo map[string]string
+type UserInfo struct {
+	User    string
+	Email   string
+	Roles   []string
+	Created time.Time
+}
 
 func (m *UserInfoHandler) Handle(rw http.ResponseWriter, req *http.Request, ses *providers.SessionState) error {
 	// by default, check to see if user information exists in a cookie
-	createCookie := true
-	userInfo, err := m.LoadCookiedData(req)
-	if err == nil {
-		createCookie = false
-		goto Save
-	}
-	userInfo, err = m.FetchUserInfo(ses.User)
+	userInfo, updated, err := m.GetUserInfo(req, ses)
 	if err != nil {
+		m.ClearCookie(rw, req)
 		return err
 	}
 
-Save:
-	m.WriteForwardedHeaders(req, userInfo)
-	if createCookie {
-		err := m.WriteCookie(rw, req, userInfo)
+	if updated {
+		err := m.SetCookie(rw, req, userInfo)
 		if err != nil {
 			return err
 		}
 	}
 
+	m.WriteForwardedHeaders(req, userInfo)
+
 	return nil
 }
 
-func (m *UserInfoHandler) LoadCookiedData(req *http.Request) (UserInfo, error) {
+func (m *UserInfoHandler) IsUserInfoStale(info *UserInfo) bool {
+	cookieAge := time.Now().Sub(info.Created)
+	return cookieAge > m.refresh
+}
+
+func (m *UserInfoHandler) GetUserInfo(req *http.Request, ses *providers.SessionState) (*UserInfo, bool, error) {
+	fetch := false
+
+	cachedInfo, err := m.LoadCookiedData(req)
+	if err != nil {
+		fetch = true
+	} else {
+		fetch = m.IsUserInfoStale(cachedInfo)
+	}
+
+	if fetch {
+		updatedInfo, userExists, err := m.FetchUserInfo(ses.User)
+		if err != nil {
+			if cachedInfo != nil {
+				return cachedInfo, false, nil
+			} else {
+				return nil, false, err
+			}
+		}
+		if !userExists {
+			// If the user no longer exists, clear this session.
+			return nil, false, fmt.Errorf("user no longer exists: %s", ses.User)
+		}
+		if updatedInfo != nil {
+			return updatedInfo, true, nil
+		}
+	}
+
+	return cachedInfo, false, nil
+}
+
+func (m *UserInfoHandler) FetchUserInfo(username string) (*UserInfo, bool, error) {
+	res, userExists, err := m.api.FetchUserInfo(username)
+	if err != nil || !userExists {
+		return nil, userExists, err
+	}
+
+	userInfo := &UserInfo{
+		User:    res.Username,
+		Email:   res.Email,
+		Roles:   res.Roles,
+		Created: time.Now(),
+	}
+	return userInfo, userExists, nil
+}
+
+func (m *UserInfoHandler) MakeCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
+	domain := req.Host
+	if h, _, err := net.SplitHostPort(domain); err == nil {
+		domain = h
+	}
+	if m.cookieDomain != "" {
+		if !strings.HasSuffix(domain, m.cookieDomain) {
+			log.Printf("Warning: request host is %q but using configured cookie domain of %q", domain, m.cookieDomain)
+		}
+		domain = m.cookieDomain
+	}
+
+	if value != "" {
+		value = cookie.SignedValue(m.cookieSeed, m.cookieName, value, now)
+	}
+	return &http.Cookie{
+		Name:     m.cookieName,
+		Value:    value,
+		Path:     "/",
+		Domain:   domain,
+		HttpOnly: m.cookieHttpOnly,
+		Secure:   m.cookieSecure,
+		Expires:  now.Add(expiration),
+	}
+}
+
+func (m *UserInfoHandler) SetCookie(rw http.ResponseWriter, req *http.Request, userInfo *UserInfo) error {
+	data := map[string]string{
+		"User":  userInfo.User,
+		"Email": userInfo.Email,
+		"Roles": strings.Join(userInfo.Roles, ","),
+	}
+	jsonStr, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	cipher, err := cookie.NewCipher(m.cookieSeed)
+	if err != nil {
+		return err
+	}
+
+	encryptedData, err := cipher.Encrypt(string(jsonStr))
+	if err != nil {
+		return err
+	}
+
+	httpCookie := m.MakeCookie(req, encryptedData, m.cookieExpire, userInfo.Created)
+
+	http.SetCookie(rw, httpCookie)
+
+	return nil
+}
+
+func (m *UserInfoHandler) ClearCookie(rw http.ResponseWriter, req *http.Request) {
+	http.SetCookie(rw, m.MakeCookie(req, "", time.Hour*-1, time.Now()))
+}
+
+func (m *UserInfoHandler) LoadCookiedData(req *http.Request) (*UserInfo, error) {
 	c, err := req.Cookie(m.cookieName)
 	if err != nil {
 		return nil, errors.New("No cookie found")
 	}
 
-	value, _, ok := cookie.Validate(c, m.cookieSeed, m.cookieExpire)
+	value, created, ok := cookie.Validate(c, m.cookieSeed, m.cookieExpire)
 	if !ok {
 		return nil, errors.New("Cookie not valid")
 	}
@@ -71,72 +181,28 @@ func (m *UserInfoHandler) LoadCookiedData(req *http.Request) (UserInfo, error) {
 		return nil, err
 	}
 
-	userInfo := make(map[string]string, 3)
-	err = json.Unmarshal([]byte(jsonString), &userInfo)
+	data := make(map[string]string, 3)
+	err = json.Unmarshal([]byte(jsonString), &data)
 	if err != nil {
 		return nil, err
+	}
+
+	userInfo := &UserInfo{
+		User:    data["User"],
+		Email:   data["Email"],
+		Roles:   strings.Split(data["Roles"], ","),
+		Created: created,
 	}
 
 	return userInfo, nil
 }
 
-func (m *UserInfoHandler) WriteCookie(rw http.ResponseWriter, req *http.Request, userInfo UserInfo) error {
-	jsonStr, err := json.Marshal(userInfo)
-	if err != nil {
-		return err
+func (m *UserInfoHandler) WriteForwardedHeaders(req *http.Request, userInfo *UserInfo) {
+	data := map[string]string{
+		"User":  userInfo.User,
+		"Email": userInfo.Email,
+		"Roles": strings.Join(userInfo.Roles, ","),
 	}
-
-	cipher, err := cookie.NewCipher(m.cookieSeed)
-	if err != nil {
-		return err
-	}
-
-	encryptedData, err := cipher.Encrypt(string(jsonStr))
-	if err != nil {
-		return err
-	}
-	cookieData := cookie.SignedValue(m.cookieSeed, m.cookieName, encryptedData, time.Now())
-
-	domain := req.Host
-	if h, _, err := net.SplitHostPort(domain); err == nil {
-		domain = h
-	}
-	if m.cookieDomain != "" {
-		if !strings.HasSuffix(domain, m.cookieDomain) {
-			log.Printf("Warning: request host is %q but using configured cookie domain of %q", domain, m.cookieDomain)
-		}
-		domain = m.cookieDomain
-	}
-
-	httpCookie := &http.Cookie{
-		Name:     m.cookieName,
-		Value:    cookieData,
-		Path:     "/",
-		Domain:   domain,
-		HttpOnly: m.cookieHttpOnly,
-		Secure:   m.cookieSecure,
-		Expires:  time.Now().Add(m.cookieExpire),
-	}
-	http.SetCookie(rw, httpCookie)
-
-	return nil
-}
-
-func (m *UserInfoHandler) FetchUserInfo(username string) (UserInfo, error) {
-	res, err := m.api.FetchUserInfo(username)
-	if err != nil {
-		return nil, err
-	}
-
-	userInfo := make(map[string]string, 3)
-	userInfo["Roles"] = strings.Join(res.Roles, ",")
-	userInfo["User"] = res.Username
-	userInfo["Email"] = res.Email
-
-	return userInfo, nil
-}
-
-func (m *UserInfoHandler) WriteForwardedHeaders(req *http.Request, data UserInfo) {
 	for key, value := range data {
 		headerKey := fmt.Sprintf("X-Forwarded-%s", key)
 		req.Header.Set(headerKey, value)

--- a/user_info_handler_test.go
+++ b/user_info_handler_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/bmizerany/assert"
+	"github.com/buzzfeed/auth_proxy/providers"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -14,29 +18,39 @@ func TestUserInfoLoadCookiedData(t *testing.T) {
 	req, _ := http.NewRequest("GET", "127.0.0.1", nil)
 	handler := &UserInfoHandler{
 		api:            nil,
-		cookieExpire:   time.Minute,
+		refresh:        time.Minute,
+		cookieExpire:   time.Minute * 30,
 		cookieDomain:   "127.0.0.1",
 		cookieName:     "test",
 		cookieSeed:     "testtesttesttest",
 		cookieHttpOnly: true,
 		cookieSecure:   false,
 	}
-	userInfo := map[string]string{
-		"test": "test",
+	userInfo := &UserInfo{
+		User:    "test",
+		Email:   "test@test.com",
+		Roles:   []string{"admin", "advertiser"},
+		Created: time.Now(),
 	}
-	err := handler.WriteCookie(rw, req, userInfo)
+	err := handler.SetCookie(rw, req, userInfo)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, rw.Header()["Set-Cookie"][0] != "", true)
 	req.Header.Set("Cookie", rw.Header()["Set-Cookie"][0])
 
 	loadedUserInfo, err := handler.LoadCookiedData(req)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, loadedUserInfo["test"], userInfo["test"])
+	assert.Equal(t, loadedUserInfo.User, userInfo.User)
+	assert.Equal(t, loadedUserInfo.Email, userInfo.Email)
+	assert.Equal(t, loadedUserInfo.Roles, userInfo.Roles)
+	assert.Equal(t, loadedUserInfo.Created.Truncate(time.Second).String(), userInfo.Created.Truncate(time.Second).String())
 }
 
 func TestUserInfoHeaders(t *testing.T) {
-	userInfo := map[string]string{
-		"test": "test",
+	userInfo := &UserInfo{
+		User:    "test",
+		Email:   "test@test.com",
+		Roles:   []string{"admin", "advertiser"},
+		Created: time.Now(),
 	}
 	handler := &UserInfoHandler{
 		api:            nil,
@@ -51,7 +65,174 @@ func TestUserInfoHeaders(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	handler.WriteForwardedHeaders(req, userInfo)
 
-	assert.Equal(t, req.Header["X-Forwarded-Test"][0], "test")
+	assert.Equal(t, req.Header["X-Forwarded-User"][0], "test")
+}
+
+func TestIsUserInfoStale(t *testing.T) {
+	handler := &UserInfoHandler{
+		refresh:        time.Second * 30,
+		cookieExpire:   time.Minute,
+		cookieDomain:   "127.0.0.1",
+		cookieName:     "test",
+		cookieSeed:     "testtesttesttest",
+		cookieHttpOnly: true,
+		cookieSecure:   false,
+	}
+
+	info := &UserInfo{
+		User:  "test",
+		Roles: []string{"admin", "advertiser"},
+		Email: "test@test.com",
+	}
+
+	info.Created = time.Now()
+	assert.Equal(t, handler.IsUserInfoStale(info), false)
+
+	info.Created = time.Now().Add(-1*handler.refresh - time.Second)
+	assert.Equal(t, handler.IsUserInfoStale(info), true)
+}
+
+type StubAuthApi struct {
+	url        *url.URL
+	status     string
+	userExists bool
+}
+
+func (a *StubAuthApi) FetchUserInfo(username string) (*AuthApiResponse, bool, error) {
+	if a.status == "down" {
+		return nil, false, errors.New("error making request to auth api")
+	}
+
+	if !a.userExists {
+		return nil, false, nil
+	}
+
+	response := &AuthApiResponse{
+		Username: username,
+		Email:    "test@test.com",
+		Roles:    []string{"admin", "advertiser"},
+	}
+	return response, true, nil
+}
+
+func (a *StubAuthApi) Validate(username string, password string) bool {
+	return true
+}
+
+func NewTestRequest(t *testing.T, handler *UserInfoHandler, info *UserInfo) *http.Request {
+	req, _ := http.NewRequest("GET", "127.0.0.1", nil)
+	rw := httptest.NewRecorder()
+
+	if info != nil {
+		err := handler.SetCookie(rw, req, info)
+		assert.Equal(t, err, nil)
+		req.Header.Set("Cookie", rw.Header()["Set-Cookie"][0])
+	}
+	return req
+}
+
+func TestGetUserInfo(t *testing.T) {
+	session := &providers.SessionState{User: "test"}
+	url, _ := url.Parse("http://127.0.0.1")
+	handler := &UserInfoHandler{
+		refresh:        time.Second * 30,
+		cookieExpire:   time.Minute,
+		cookieDomain:   "127.0.0.1",
+		cookieName:     "test",
+		cookieSeed:     "testtesttesttest",
+		cookieHttpOnly: true,
+		cookieSecure:   false,
+	}
+
+	stubInfo := &UserInfo{
+		User:    "test",
+		Roles:   []string{"admin", "advertiser"},
+		Email:   "test@test.com",
+		Created: time.Now(),
+	}
+
+	testCases := []struct {
+		input  map[string]string
+		output map[string]bool
+	}{
+		{
+			map[string]string{"cache": "none", "api": "down"},
+			map[string]bool{"error": true, "updated": false, "info": false},
+		},
+		{
+			map[string]string{"cache": "none", "api": "up"},
+			map[string]bool{"error": false, "updated": true, "info": true},
+		},
+		{
+			map[string]string{"cache": "none", "api": "dne"},
+			map[string]bool{"error": true, "updated": false, "info": false},
+		},
+		{
+			map[string]string{"cache": "valid", "api": "down"},
+			map[string]bool{"error": false, "updated": false, "info": true},
+		},
+		{
+			map[string]string{"cache": "valid", "api": "up"},
+			map[string]bool{"error": false, "updated": false, "info": true},
+		},
+		{
+			map[string]string{"cache": "valid", "api": "dne"},
+			map[string]bool{"error": false, "updated": false, "info": true},
+		},
+		{
+			// If the api is down, continue to use the stale cache.
+			map[string]string{"cache": "stale", "api": "down"},
+			map[string]bool{"error": false, "updated": false, "info": true},
+		},
+		{
+			map[string]string{"cache": "stale", "api": "up"},
+			map[string]bool{"error": false, "updated": true, "info": true},
+		},
+		{
+			map[string]string{"cache": "stale", "api": "dne"},
+			map[string]bool{"error": true, "updated": false, "info": false},
+		},
+	}
+	for _, testCase := range testCases {
+		var apiStatus string
+		var userExists bool
+		if testCase.input["api"] == "down" {
+			apiStatus = "down"
+			userExists = true
+		} else if testCase.input["api"] == "dne" {
+			apiStatus = "up"
+			userExists = false
+
+		} else {
+			apiStatus = "up"
+			userExists = true
+		}
+
+		var cachedInfo *UserInfo
+		if testCase.input["cache"] == "none" {
+			cachedInfo = nil
+		} else if testCase.input["cache"] == "stale" {
+			cachedInfo = stubInfo
+			cachedInfo.Created = time.Now().Add(-1*handler.refresh - time.Second)
+		} else {
+			cachedInfo = stubInfo
+			cachedInfo.Created = time.Now()
+		}
+
+		handler.api = &StubAuthApi{
+			url:        url,
+			status:     apiStatus,
+			userExists: userExists,
+		}
+		req := NewTestRequest(t, handler, cachedInfo)
+		info, updated, err := handler.GetUserInfo(req, session)
+
+		log.Printf("input: %+v expected output: %+v", testCase.input, testCase.output)
+
+		assert.Equal(t, info != nil, testCase.output["info"])
+		assert.Equal(t, updated, testCase.output["updated"])
+		assert.Equal(t, err != nil, testCase.output["error"])
+	}
 }
 
 func TestUserInfoFetch(t *testing.T) {
@@ -80,9 +261,9 @@ func TestUserInfoFetch(t *testing.T) {
 		cookieSecure:   false,
 	}
 
-	userInfo, err := handler.FetchUserInfo("test")
+	userInfo, _, err := handler.FetchUserInfo("test")
 	assert.Equal(t, err, nil)
-	assert.Equal(t, userInfo["Roles"], "test1,test2")
-	assert.Equal(t, userInfo["User"], "test")
-	assert.Equal(t, userInfo["Email"], "test@buzzfeed.com")
+	assert.Equal(t, userInfo.User, "test")
+	assert.Equal(t, userInfo.Email, "test@buzzfeed.com")
+	assert.Equal(t, userInfo.Roles, []string{"test1", "test2"})
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.6"
+const VERSION = "2.0.1-buzzfeed0.7"


### PR DESCRIPTION
This sets the user info cookie expiration to the same as the auth proxy cookie expiration.
`--auth-api-refresh` no longer sets the expiration for the user info cookie. Instead, it is compared to when the  user info cookie was written, and hits the `refresh` API if enough time has passed.

If the `auth_api` is down, logged in users won't get `refresh`ed, but will continue to use their existing user info stored in their cookie.

If a user has been deleted, both cookies will be cleared and the user will be logged out.