### PR TITLE
auth_proxy: Remove sign in message from template.

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -2856,9 +2856,6 @@ func getTemplates() *template.Template {
       <div class="xs-col-12 xs-py2">
         <form method="GET" action="{{.ProxyPrefix}}/start">
           <input type="hidden" name="rd" value="{{.Redirect}}">
-          {{ if .SignInMessage }}
-          <p>{{.SignInMessage}}</p>
-          {{ end}}
           <button type="submit" class="button button--secondary xs-col-12 xs-my3">Log in with Your BuzzFeed Email</button>
         </form>
       </div>

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.7"
+const VERSION = "2.0.1-buzzfeed0.8"


### PR DESCRIPTION
Removes extra sign in message from the login template while using `--email-domain`.
Before:
![screen shot 2016-02-25 at 1 27 33 pm](https://cloud.githubusercontent.com/assets/272536/13329742/a873deb0-dbc3-11e5-966c-92a0c8fa8cfc.png)


After:
![screen shot 2016-02-25 at 1 27 44 pm](https://cloud.githubusercontent.com/assets/272536/13329748/ad8083e0-dbc3-11e5-9293-354bdd74d085.png)


cc @buzzfeed/platform-infra 