### PR TITLE
INFRA-894: Remove email reference from sign in page.

### DIFF
--- a/static/sign_in.html
+++ b/static/sign_in.html
@@ -14,9 +14,6 @@
       <div class="xs-col-12 xs-py2">
         <form method="GET" action="{{.ProxyPrefix}}/start">
           <input type="hidden" name="rd" value="{{.Redirect}}">
-          {{ if .SignInMessage }}
-          <p>{{.SignInMessage}}</p>
-          {{ end}}
           <button type="submit" class="button button--secondary xs-col-12 xs-my3">Log in with Your BuzzFeed Email</button>
         </form>
       </div>
@@ -31,7 +28,7 @@
       <div class="xs-py2">
         <form method="POST" action="{{.ProxyPrefix}}/sign_in">
           <input type="hidden" name="rd" value="{{.Redirect}}">
-          <label class="form-label xs-pt3">Your Username or Email Address</label>
+          <label class="form-label xs-pt3">Your Username</label>
           <input type="text" name="username" class="text-input xs-col-12">
           <label class="form-label xs-pt2">Your Password</label>
           <input type="password" name="password" class="text-input xs-col-12">

--- a/templates.go
+++ b/templates.go
@@ -2870,7 +2870,7 @@ func getTemplates() *template.Template {
       <div class="xs-py2">
         <form method="POST" action="{{.ProxyPrefix}}/sign_in">
           <input type="hidden" name="rd" value="{{.Redirect}}">
-          <label class="form-label xs-pt3">Your Username or Email Address</label>
+          <label class="form-label xs-pt3">Your Username</label>
           <input type="text" name="username" class="text-input xs-col-12">
           <label class="form-label xs-pt2">Your Password</label>
           <input type="password" name="password" class="text-input xs-col-12">

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.8"
+const VERSION = "2.0.1-buzzfeed0.9"


### PR DESCRIPTION
The auth api doesn't currently support login via email address. This removes the reference to email from the auth api login form. 

![screen shot 2016-02-26 at 3 43 16 pm](https://cloud.githubusercontent.com/assets/272536/13364889/ae63e888-dc9f-11e5-9e3e-f13f71b644df.png)
