### PR TITLE
auth_proxy: Handle 403 responses from auth_api during refresh.

### DIFF
--- a/auth_api.go
+++ b/auth_api.go
@@ -73,6 +73,11 @@ func (a *DefaultAuthApi) FetchUserInfo(username string) (*AuthApiResponse, bool,
 		return nil, false, nil
 	}
 
+	if resp.StatusCode == 403 {
+		log.Printf("user no longer active: %s", username)
+		return nil, false, nil
+	}
+
 	if resp.StatusCode != 200 {
 		err = fmt.Errorf("got %d from %q %s", resp.StatusCode, url, body)
 		log.Printf("unexpected status code: %s", err)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.9"
+const VERSION = "2.0.1-buzzfeed0.10"


### PR DESCRIPTION
The `/refresh` endpoint may return a `403` if the user had been deleted since authenticating.
Handle these by signing the user out. 

@buzzfeed/platform-infra 