### PR TITLE
INFRA-968: Add support to send auth token via X-Auth-Token header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ An example [oauth2_proxy.cfg](contrib/oauth2_proxy.cfg.example) config file is i
 ```
 Usage of auth_proxy:
   -auth-api-url="": [http://]<addr>:<port>/<path> of the BuzzFeed Auth API endpoint
+  -auth-api-auth-token="Auth Token to authenticate to the BuzzFeed Auth API":
   -auth-api-refresh="24h": refresh user info after this duration
   -auth-api-cookie-name="_auth_proxy_user_info": the name of the cookie for storing user info
   -authenticated-emails-file="": authenticate against emails via file (one per line)

--- a/auth_api.go
+++ b/auth_api.go
@@ -17,6 +17,7 @@ type AuthApi interface {
 
 type DefaultAuthApi struct {
 	url *url.URL
+	authToken string
 }
 
 type AuthApiRequest struct {
@@ -30,7 +31,7 @@ type AuthApiResponse struct {
 	Roles    []string `json:"roles"`
 }
 
-func NewAuthApiFromUrl(rawurl string) (*DefaultAuthApi, error) {
+func NewAuthApi(rawurl string, authToken string) (*DefaultAuthApi, error) {
 	url, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err
@@ -38,6 +39,7 @@ func NewAuthApiFromUrl(rawurl string) (*DefaultAuthApi, error) {
 
 	return &DefaultAuthApi{
 		url: url,
+		authToken: authToken,
 	}, nil
 }
 
@@ -51,6 +53,11 @@ func (a *DefaultAuthApi) FetchUserInfo(username string) (*AuthApiResponse, bool,
 	}
 
 	request.Header.Set("Content-Type", "application/json")
+
+	if a.authToken != "" {
+		log.Printf("setting X-Auth-Token")
+		request.Header.Set("X-Auth-Token", a.authToken)
+	}
 
 	log.Printf("making request to auth_api: %s", url)
 	resp, err := http.DefaultClient.Do(request)
@@ -108,6 +115,11 @@ func (a *DefaultAuthApi) Validate(username string, password string) bool {
 		return false
 	}
 	request.Header.Set("Content-Type", "application/json")
+
+	if a.authToken != "" {
+		log.Printf("setting X-Auth-Token")
+		request.Header.Set("X-Auth-Token", a.authToken)
+	}
 
 	log.Printf("making request to auth_api: %s for user: %q", a.url.String(), username)
 	resp, err := http.DefaultClient.Do(request)

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	flagSet.String("scope", "", "Oauth scope specification")
 
 	flagSet.String("auth-api-url", "", "[http://]<addr>:<port>/<path> of the BuzzFeed Auth API endpoint")
+	flagSet.String("auth-api-auth-token", "", "Auth Token to authenticate to the BuzzFeed Auth API")
 	flagSet.Duration("auth-api-refresh", time.Hour*24, "refresh user info after this duration")
 	flagSet.String("auth-api-cookie-name", "_auth_proxy_user_info", "the name of the cookie for storing user info")
 
@@ -114,7 +115,7 @@ func main() {
 
 	if opts.AuthApiUrl != "" {
 		log.Printf("using auth api %s", opts.AuthApiUrl)
-		oauthproxy.AuthApi, err = NewAuthApiFromUrl(opts.AuthApiUrl)
+		oauthproxy.AuthApi, err = NewAuthApi(opts.AuthApiUrl, opts.AuthApiAuthToken)
 		if err != nil {
 			log.Fatalf("Fatal: invalid auth api url %s", opts.AuthApiUrl)
 		}

--- a/options.go
+++ b/options.go
@@ -56,6 +56,7 @@ type Options struct {
 
 	// BuzzFeed Auth API options
 	AuthApiUrl        string        `flag:"auth-api-url" cfg:"auth_api_url"`
+	AuthApiAuthToken  string	`flag:"auth-api-auth-token" cfg:"auth_api_auth_token"`
 	AuthApiRefresh    time.Duration `flag:"auth-api-refresh" cfg:"auth_api_refresh"`
 	AuthApiCookieName string        `flag:"auth-api-cookie-name" cfg:"auth_api_cookie_name"`
 

--- a/user_info_handler_test.go
+++ b/user_info_handler_test.go
@@ -250,7 +250,7 @@ func TestUserInfoFetch(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	authApi, err := NewAuthApiFromUrl(backend.URL)
+	authApi, err := NewAuthApi(backend.URL, "")
 	handler := &UserInfoHandler{
 		api:            authApi,
 		cookieExpire:   time.Minute,

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.10"
+const VERSION = "2.0.1-buzzfeed0.11"


### PR DESCRIPTION
Adds the command line option `--auth-api-auth-token` and sets the `X-Auth-Token` header when making requests to the auth and refresh endpoints.

@buzzfeed/platform-infra 