### PR TITLE
auth_proxy: Hide footnote when not showing the login form.

### DIFF
--- a/static/sign_in.html
+++ b/static/sign_in.html
@@ -41,10 +41,13 @@
       <p class="text-gray--lightest text-6 xs-text-center">Secured with <a href="https://github.com/buzzfeed/auth_proxy#auth_proxy">Auth Proxy</a> version {{.Version}}</p>
        -->
     </section>
+
+    {{ if .CustomLogin }}
     <section class="footnote xs-col-4 xs-py4 xs-mx-auto text-4">
-        <p class="xs-pb1"><strong>Forgot your password?</strong></p>
-        <p class="xs-pb1">Advertisers, please contact your BuzzFeed Client Services Representative</p>
-        <p>Community users, <a target="_blank" href="community-user-login-instruction.html">please follow these instructions</a></p>
+      <p class="xs-pb1"><strong>Forgot your password?</strong></p>
+      <p class="xs-pb1">Advertisers, please contact your BuzzFeed Client Services Representative</p>
+      <p>Community users, <a target="_blank" href="community-user-login-instruction.html">please follow these instructions</a></p>
     </section>
+    {{ end }}
   </body>
 </html>

--- a/templates.go
+++ b/templates.go
@@ -2892,11 +2892,13 @@ func getTemplates() *template.Template {
       <p class="text-gray--lightest text-6 xs-text-center">Secured with <a href="https://github.com/buzzfeed/auth_proxy#auth_proxy">Auth Proxy</a> version {{.Version}}</p>
        -->
     </section>
+    {{ if .CustomLogin }}
     <section class="footnote xs-col-4 xs-py4 xs-mx-auto text-4">
-	<p class="xs-pb1"><strong>Forgot your password?</strong></p>
-	<p class="xs-pb1">Advertisers, please contact your BuzzFeed Client Services Representative</p>
-	<p>Community users, <a target="_blank" href="{{.ProxyPrefix}}/forgot_password">please follow these instructions</a></p>
+      <p class="xs-pb1"><strong>Forgot your password?</strong></p>
+      <p class="xs-pb1">Advertisers, please contact your BuzzFeed Client Services Representative</p>
+      <p>Community users, <a target="_blank" href="community-user-login-instruction.html">please follow these instructions</a></p>
     </section>
+    {{ end }}
   </body>
 </html>
 {{end}}`)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.12"
+const VERSION = "2.0.1-buzzfeed0.13"


### PR DESCRIPTION
We should hide the reset password footnote when not showing the login form.

![screen shot 2016-05-11 at 2 57 45 pm](https://cloud.githubusercontent.com/assets/272536/15194580/2702e16c-1789-11e6-803f-fa0af288b14c.png)
![screen shot 2016-05-11 at 2 57 52 pm](https://cloud.githubusercontent.com/assets/272536/15194581/2702cf24-1789-11e6-9bbd-01ff2ecca898.png)

@buzzfeed/platform-infra @oiyana 