### PR TITLE
INFRA: wip: proof of concept http-https-redirect

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,8 @@ func main() {
 	flagSet.Duration("auth-api-refresh", time.Hour*24, "refresh user info after this duration")
 	flagSet.String("auth-api-cookie-name", "_auth_proxy_user_info", "the name of the cookie for storing user info")
 
+	flagSet.Bool("http-https-redirect", true, "redirect http requests to https")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
@@ -132,7 +134,7 @@ func main() {
 	}
 
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging),
+		Handler: RedirectHandler(opts.HttpHttpsRedirect, LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging)),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/options.go
+++ b/options.go
@@ -60,6 +60,9 @@ type Options struct {
 	AuthApiRefresh    time.Duration `flag:"auth-api-refresh" cfg:"auth_api_refresh"`
 	AuthApiCookieName string        `flag:"auth-api-cookie-name" cfg:"auth_api_cookie_name"`
 
+	// http-https redirect options
+	HttpHttpsRedirect bool `flag:"http-https-redirect" cfg:"http_https_redirect"`
+
 	// internal values that are set after config validation
 	redirectUrl   *url.URL
 	proxyUrls     []*url.URL
@@ -164,7 +167,7 @@ func (o *Options) Validate() error {
 
 	if len(msgs) != 0 {
 		return fmt.Errorf("Invalid configuration:\n  %s",
-			strings.Join(msgs, "\n  "))
+			strings.Join(msgs, "\n	"))
 	}
 	return nil
 }

--- a/redirect_handler.go
+++ b/redirect_handler.go
@@ -1,0 +1,15 @@
+package main
+
+import "net/http"
+
+func RedirectHandler(httpHttpsRedirect bool, h http.Handler) http.Handler {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		// if the request is HTTPS or we dont care about redirecting, then go ahead and pass the request along
+		if req.Header.Get("X-Forwarded-Proto") == "https" || !httpHttpsRedirect {
+			h(rw, req)
+			return
+		}
+
+		http.Redirect(rw, req, "https://"+req.Host+req.URL.String(), http.StatusMovedPermanently)
+	}
+}


### PR DESCRIPTION
cc @buzzfeed/platform-infra-squad @mreiferson

I was super curious, in the context of https://github.com/buzzfeed/mono/pull/8508 about what it would take to teach `buzzfeed/auth_proxy` to redirect http to https traffic.

This would allow us to do two things:

1.) drop the nginx requirement + rewrite logic we have (a good example of this is how `deploy_ui_auth_proxy` handles this!)
2.) enable `allow_insecure` in **rig** for any `auth_proxy` serice, meaning that `http://` works and redirects as expected for folks :)

This isn't a fully working implementation yet, but the core of how it'd come out is there. It would require folks to use `buzzfeed/auth_proxy` in `mono` but I actually think that might be a good thing since we're managing this repo now.

I literally timeboxed 15 minutes to write this code, so if this is nothing something worth working on, totally let me know! nothing something worth working on, totally let me know! nothing something worth working on, totally let me know! nothing something worth working on, totally let me know!

Curious what ya'll think!