### PR TITLE
SECURITY-50: Verify that redirect is relative domain

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -356,7 +356,7 @@ func (p *OauthProxy) GetRedirect(req *http.Request) (string, error) {
 
 	redirect := req.FormValue("rd")
 
-	if redirect == "" {
+	if redirect == "" || !strings.HasPrefix(redirect, "/") {
 		redirect = "/"
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.16"
+const VERSION = "2.0.1-buzzfeed0.17"


### PR DESCRIPTION
This prevents the form field `rd` from being set to a full url with different host and causing the redirect to bounce the user to a different site.

@yellottyellott 