### PR TITLE
SECURITY-650: verify redirect doesn't start with //

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     set -e
 
+    apt-get update
     apt-get install -y git
     chown -R vagrant:vagrant /opt/go
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -356,7 +356,7 @@ func (p *OauthProxy) GetRedirect(req *http.Request) (string, error) {
 
 	redirect := req.FormValue("rd")
 
-	if redirect == "" || !strings.HasPrefix(redirect, "/") {
+	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
 		redirect = "/"
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.17"
+const VERSION = "2.0.1-buzzfeed0.18"


### PR DESCRIPTION
Make sure the redirect doesn't start with `//`. `//` means use the same protocol (eh http or https) so can be used to redirect off site.

Also updated the provisioning shell script to update deps since the older version of git is no longer valid.

@yellottyellott @mccutchen 