### PR TITLE
SECURITY-957: Do not redirect if there is a backslash

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -356,11 +356,15 @@ func (p *OauthProxy) GetRedirect(req *http.Request) (string, error) {
 
 	redirect := req.FormValue("rd")
 
-	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	return p.verifyRedirect(redirect), nil
+}
+
+func (p *OauthProxy) verifyRedirect(redirect string) (string) {
+	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") || strings.Contains(redirect, "\\") {
 		redirect = "/"
 	}
 
-	return redirect, err
+	return redirect
 }
 
 func (p *OauthProxy) IsWhitelistedPath(path string) (ok bool) {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -488,3 +488,18 @@ func TestProcessCookieFailIfRefreshSetAndCookieExpired(t *testing.T) {
 		t.Errorf("expected nil session %#v", session)
 	}
 }
+
+func verifyRedirect(t *testing.T, given string, expected string) {
+	OP := &OauthProxy{}
+	redirect := OP.verifyRedirect(given)
+	assert.Equal(t, redirect, expected)
+}
+
+func TestGetRedirect(t *testing.T) {
+	verifyRedirect(t, "garbage", "/")
+	verifyRedirect(t, "", "/")
+	verifyRedirect(t, "/real-uri", "/real-uri")
+	verifyRedirect(t, "http://example.com/", "/")
+	verifyRedirect(t, "//example.com/", "/")
+	verifyRedirect(t, "/\\\\example.com/", "/")
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.18"
+const VERSION = "2.0.1-buzzfeed0.19"


### PR DESCRIPTION
Based on this report: https://buzzfeed.atlassian.net/browse/SECURITY-957

Redirects that tried to go to `/\\example.com/` redirect to the example.com domain.

This prevents that by forcing a redirect to the root if there is a backslash.

@yellottyellott @mccutchen 