### PR TITLE
SECURITY-1112: Disable BuzzFeed login with email addresses

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -328,7 +328,7 @@ func (p *OauthProxy) ManualSignIn(rw http.ResponseWriter, req *http.Request) (st
 	}
 	user := req.FormValue("username")
 	passwd := req.FormValue("password")
-	if user == "" {
+	if user == "" || strings.Contains(user, "@") {
 		return "", false, providers.AuthTypeNone, false
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.0.1-buzzfeed0.19"
+const VERSION = "2.0.1-buzzfeed0.20"


### PR DESCRIPTION
This is addressing this hacker one report: https://buzzfeed.atlassian.net/browse/SECURITY-1112

The dashbird login already says not to login with email address, this is enforcing it.

This prevents an account with an email address name that matches a different accounts login name from getting the second accounts view.

@buzzfeed/reporting-tools-eng @buzzfeed/oo-infra-security 
@yellottyellott @mccutchen